### PR TITLE
OBP ütközőtest módosítva

### DIFF
--- a/frontend/game/Collider.js
+++ b/frontend/game/Collider.js
@@ -13,6 +13,10 @@ export default class Collider {
     console.warn("onAttach() must be implemented by the subclass!");
   }
 
+  init() {
+    // console.warn("init() must be implemented by the subclass!");
+  }
+
   /**
    * This function should evalute whether the collider needs updates based on its dirty state.
    */

--- a/frontend/game/Collision.js
+++ b/frontend/game/Collision.js
@@ -39,5 +39,7 @@ export default class Collision {
 
     // vec2.reset(this.a.velocity);
     // vec2.reset(this.b.velocity);
+
+    return this;
   }
 }

--- a/frontend/game/collider/CompositeCollider.js
+++ b/frontend/game/collider/CompositeCollider.js
@@ -38,15 +38,12 @@ export default class CompositeCollider extends Collider {
 
   // prettier-ignore
   createConvexPart(vertexBuffer, objectGroup) {
-    const model = new Model(objectGroup, Model.COPY_MODE.PRESERVE);
-
-    Shape.MERGE(vertexBuffer, objectGroup[0].shape.mergeModeRequest, model.objects);
     const rigidbody = new Rigidbody({
       game: this.entity.game,
-      model: model,
+      model: new Model(objectGroup, Model.COPY_MODE.PRESERVE),
     })
       .apply(this.entity)
-      .setShapeCollider(new OBP(null, ...vertexBuffer));
+      .setShapeCollider(new OBP());
 
     this.decomposed.push(rigidbody);
   }

--- a/frontend/game/collider/OBP.js
+++ b/frontend/game/collider/OBP.js
@@ -2,6 +2,7 @@ import Collider from "../Collider.js";
 import * as vec from "../../common/vec.js";
 import * as vec2 from "../../common/vec2.js";
 import * as vec3 from "../../common/vec3.js";
+import Shape from "../Shape.js";
 
 export default class OBP extends Collider {
   static DIRTY = Object.freeze({
@@ -9,18 +10,19 @@ export default class OBP extends Collider {
     TRANSFORM: 1 << 0,
   });
 
-  constructor(entity = null, ...vertices) {
+  constructor(entity = null) {
     super(entity);
-
-    this.vertices = vec.create(vertices.length);
-    for (let i = 0; i < vertices.length; i++) this.vertices[i] = vertices[i];
-    this.worldVertices = vec.create(vertices.length);
-    this.axes = vec.create(vertices.length);
-    this.center = vec2.create();
   }
 
   onAttach(entity) {
     this.entity = entity;
+
+    // prettier-ignore
+    {
+      this.init(
+        ...Shape.MERGE(entity.game.buffer.arrn_1, entity.model.objects[0].shape.mergeModeRequest, entity.model.objects)
+      );
+    }
   }
 
   onGeometryChange() {
@@ -35,6 +37,14 @@ export default class OBP extends Collider {
     if (this.dirty === OBP.DIRTY.NONE) return;
 
     this.set();
+  }
+
+  init(...vertices) {
+    this.vertices = vec.create(vertices.length);
+    for (let i = 0; i < vertices.length; i++) this.vertices[i] = vertices[i];
+    this.worldVertices = vec.create(vertices.length);
+    this.axes = vec.create(vertices.length);
+    this.center = vec2.create();
   }
 
   set() {


### PR DESCRIPTION
- az OBP osztály konstruktorából a csúcsok fogadásának lehetősége eltávolítva
- az entitásfüggő inicializációs logika áthelyezve az OBP.init metódusba, amely hívása az onAttach esemény bekövetkeztekor történik